### PR TITLE
TJ operator can have a Real

### DIFF
--- a/src/print_tree/stream_operations.rs
+++ b/src/print_tree/stream_operations.rs
@@ -620,7 +620,12 @@ pub fn operation_info(
                             formatted_string.push(' ');
                         }
                     }
-                    _ => log::warn!("Only Strings and Integers expected in `TJ` operator."),
+                    Object::Real(float_value) => {
+                        if float_value.is_sign_negative() {
+                            formatted_string.push(' ');
+                        }
+                    }
+                    _ => log::warn!("Only Strings and Numbers expected in `TJ` operator."),
                 }
             }
             OperationInfo {


### PR DESCRIPTION
This avoid warnings thrown with the TJ operator as they have `Real`. The spec clearly say "numbers" (page 408 of the PDF 1.7 spec)